### PR TITLE
スキルで置きなおした時にターン移行しないように修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,4 @@ Assets/TextMesh Pro
 Assets/TextMesh Pro.meta
 # AssetStoreTools フォルダ以下をすべて無視
 Assets/AssetStoreTools/
+Assets/AssetTools/

--- a/.gitignore
+++ b/.gitignore
@@ -103,4 +103,3 @@ Assets/TextMesh Pro
 Assets/TextMesh Pro.meta
 # AssetStoreTools フォルダ以下をすべて無視
 Assets/AssetStoreTools/
-Assets/AssetTools/

--- a/Assets/Prefabs/BossPanel.prefab
+++ b/Assets/Prefabs/BossPanel.prefab
@@ -53,6 +53,7 @@ GameObject:
   - component: {fileID: 1808552410207205092}
   - component: {fileID: 5696620266026397888}
   - component: {fileID: -2437602233323525302}
+  - component: {fileID: 6548206110120861408}
   m_Layer: 0
   m_Name: BossPanel
   m_TagString: Untagged
@@ -76,6 +77,7 @@ Transform:
   - {fileID: 1219586031362287208}
   - {fileID: 775907857123469292}
   - {fileID: 6387750711681351625}
+  - {fileID: 6340336208962160149}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &5085685963464608945
@@ -281,6 +283,22 @@ MonoBehaviour:
   _panelMinimalizeSize: 0.9
   _panelMinimalizeSpeed: 1
   _panelReturnSpeed: 1
+--- !u!114 &6548206110120861408
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 448241291402004874}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a34383aefafc4a443942300b68884a25, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::EnemyDeathPreviewEffect
+  _deathMark: {fileID: 7362184003743366987}
+  _effectScale: 1.5
+  _effectDuration: 0.2
+  _backEffectDuration: 1
 --- !u!1 &1029786972708488799
 GameObject:
   m_ObjectHideFlags: 0
@@ -1561,3 +1579,74 @@ MonoBehaviour:
   m_BlockingMask:
     serializedVersion: 2
     m_Bits: 4294967295
+--- !u!1001 &4222853649011631195
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 6577069989502047705}
+    m_Modifications:
+    - target: {fileID: 6679168502154353424, guid: 74fc940c97dd3e242b45939baef213ff, type: 3}
+      propertyPath: m_Name
+      value: EnemyCanBeKilledSprite
+      objectReference: {fileID: 0}
+    - target: {fileID: 6679168502154353424, guid: 74fc940c97dd3e242b45939baef213ff, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7883534885429731918, guid: 74fc940c97dd3e242b45939baef213ff, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7883534885429731918, guid: 74fc940c97dd3e242b45939baef213ff, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7883534885429731918, guid: 74fc940c97dd3e242b45939baef213ff, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7883534885429731918, guid: 74fc940c97dd3e242b45939baef213ff, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7883534885429731918, guid: 74fc940c97dd3e242b45939baef213ff, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7883534885429731918, guid: 74fc940c97dd3e242b45939baef213ff, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7883534885429731918, guid: 74fc940c97dd3e242b45939baef213ff, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7883534885429731918, guid: 74fc940c97dd3e242b45939baef213ff, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7883534885429731918, guid: 74fc940c97dd3e242b45939baef213ff, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7883534885429731918, guid: 74fc940c97dd3e242b45939baef213ff, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 74fc940c97dd3e242b45939baef213ff, type: 3}
+--- !u!4 &6340336208962160149 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7883534885429731918, guid: 74fc940c97dd3e242b45939baef213ff, type: 3}
+  m_PrefabInstance: {fileID: 4222853649011631195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &7362184003743366987 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6679168502154353424, guid: 74fc940c97dd3e242b45939baef213ff, type: 3}
+  m_PrefabInstance: {fileID: 4222853649011631195}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/Scripts/BoardManager.cs
+++ b/Assets/Scripts/BoardManager.cs
@@ -174,12 +174,10 @@ public class BoardManager : MonoBehaviour
     /// </summary>
     /// <param name="pos"></param>
     /// <param name="panel"></param>
-    public void ReplacePanel(Vector2Int pos, Panel panel, bool isPlayer)
+    public void ReplacePanel(Vector2Int pos, Panel panel)
     {
-        if (isPlayer)
-            _boardArray[pos.x, pos.y].DestroyThis();
-        else
-            Destroy(_boardArray[pos.x, pos.y]);
+        Destroy(_boardArray[pos.x, pos.y].gameObject);
+        _boardArray[pos.x, pos.y] = null;
 
         //  新しいパネルを生成、初期化
         Panel newPanel = Instantiate(panel, _boardRoot);
@@ -283,6 +281,8 @@ public class BoardManager : MonoBehaviour
             {
                 Panel removed = _selectedStack.Pop();
                 removed.GetComponent<SelectionScaleEffect>()?.ReturnPanelScale();
+                if (removed is EnemyPanel enemyPanel)
+                    enemyPanel.DeathEffect.ResetEffect();
             }
 
             UpdateEnemyDeathPreviews();

--- a/Assets/Scripts/BossPanel.cs
+++ b/Assets/Scripts/BossPanel.cs
@@ -100,7 +100,7 @@ public class BossPanel : EnemyPanel
         // 取得したパネルを敵パネルに変換する
         foreach (Panel panel in panels)
         {
-            _rm.BoardManager.ReplacePanel(panel.BoardPos, _enemyPanel, false);
+            _rm.BoardManager.ReplacePanel(panel.BoardPos, _enemyPanel);
         }
     }
 

--- a/Assets/Scripts/Resolving/EnemyDeathCheckUtility.cs
+++ b/Assets/Scripts/Resolving/EnemyDeathCheckUtility.cs
@@ -17,8 +17,8 @@ public static class EnemyDeathCheckUtility
         // 敵Hpへのダメージ
         int enemyHpDamage = playerAttack > enemyShieldAbsorb ? playerAttack - enemyShieldAbsorb : 0;
 
-        bool isdead = enemy.Hp - enemyHpDamage <= 0;
+        bool isDead = enemy.Hp - enemyHpDamage <= 0;
 
-        return isdead;
+        return isDead;
     }
 }

--- a/Assets/Scripts/Skill/ShieldToSwordSkill.cs
+++ b/Assets/Scripts/Skill/ShieldToSwordSkill.cs
@@ -15,7 +15,7 @@ public class ShieldToSwordSkill : SkillBase
         {
             if (panel is ShieldPanel shieldPanel)
             {
-                _boardManager.ReplacePanel(shieldPanel.BoardPos, _swordPanelPrefab, true);
+                _boardManager.ReplacePanel(shieldPanel.BoardPos, _swordPanelPrefab);
             }
         }
     }


### PR DESCRIPTION
直接Destroyしてターン移行しないように
BossPanelがEnemyPanelを継承しているので倒すことができるときにnullを返してしまうバグを修正